### PR TITLE
[waybar] Adding forgotten memory text color

### DIFF
--- a/waybar/style.css
+++ b/waybar/style.css
@@ -120,6 +120,7 @@ label:focus {
 
 #memory {
     background-color: #ebdbb2;
+    color: #000000;
 }
 
 #backlight {


### PR DESCRIPTION
I think you forgot to add the text color for the memory in the waybar stylesheet :stuck_out_tongue: !